### PR TITLE
Change chess engine api and integrate with the chess application

### DIFF
--- a/chess/build.gradle.kts
+++ b/chess/build.gradle.kts
@@ -34,12 +34,13 @@ application {
 
 // Code Style (aesthetic...)
 spotless {
+    isEnforceCheck = false
     scala {
         scalafmt(libs.versions.scalafmt.version.get()).configFile(".scalafmt.conf")
         licenseHeaderFile(file("../LICENSE-HEADER"), "package ")
     }
-    // always apply formatting when building the project
-    tasks.spotlessCheck.get().dependsOn(tasks.spotlessApply)
+    // always apply formatting before building, running or testing the project
+    tasks.compileScala.get().dependsOn(tasks.spotlessApply)
 }
 
 // Code Linting (error prevention...)
@@ -47,7 +48,14 @@ val wartRemoverCompileOptions = WartRemover.configFile(file(".wartremover.conf")
 
 // Scala Compiler Options
 tasks.withType(ScalaCompile::class.java) {
-    scalaCompileOptions.additionalParameters = listOf("-Xtarget:8", "-indent", "-rewrite") + wartRemoverCompileOptions
+    scalaCompileOptions.additionalParameters =
+        listOf(
+            "-Xtarget:8",
+            "-indent",
+            "-rewrite",
+            "-feature",
+            "-language:implicitConversions"
+        ) + wartRemoverCompileOptions
 }
 
 // Scala Test

--- a/chess/src/main/scala/io/github/chess/adapters/Adapter.scala
+++ b/chess/src/main/scala/io/github/chess/adapters/Adapter.scala
@@ -6,13 +6,11 @@
  */
 package io.github.chess.adapters
 
-import io.vertx.core.Vertx
+/**
+ * Represents an adapter that allows to interact with a specific port of a service,
+ * exposing the port through a specific technology (i.e. HTTP, MQTT...).
+ */
+trait Adapter[Port]:
 
-/** Represents an adapter to help view communicate with the logic. */
-trait AbstractAdapter[Port]:
-
-  /**
-   * Returns the port (controller) of the adapter
-   * @return the port (controller)
-   */
-  def port: Port
+  /** @return the port exposed by this adapter */
+  protected def port: Port

--- a/chess/src/main/scala/io/github/chess/adapters/ChessLocalAdapter.scala
+++ b/chess/src/main/scala/io/github/chess/adapters/ChessLocalAdapter.scala
@@ -1,0 +1,16 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.adapters
+
+import io.github.chess.ports.ChessPort
+import io.vertx.core.Vertx
+
+/**
+ * Represents an adapter that allows to interact with a specific port
+ * of a service, exposing the port to local interactions.
+ */
+class ChessLocalAdapter(override val port: ChessPort) extends Adapter[ChessPort]

--- a/chess/src/main/scala/io/github/chess/model/ChessBoard.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessBoard.scala
@@ -7,12 +7,12 @@
 package io.github.chess.model
 
 import io.github.chess.events.EndTurnEvent
+import io.github.chess.model.ChessBoardBuilder.DSL.*
 import io.github.chess.model.Team.{BLACK, WHITE}
 import io.vertx.core.Vertx
 
 /** The trait representing the concept of a Chess Board. */
 trait ChessBoard:
-
   /**
    * Gives access to all the [[Piece]]s that are present on the board.
    * @return the map containing both white and black [[Piece]]s of the board
@@ -20,66 +20,83 @@ trait ChessBoard:
   def pieces: Map[Position, Piece]
 
   /**
-   * Gives all the available positions for a pieces placed in a specified position.
-   * @param position the [[Position]] where the piece to be moved is placed
-   * @return all the available positions that could be performed by the piece
+   * Updates the chess board assigning the specified piece to the specified position.
+   * @param position the specified position
+   * @param piece the specified piece
    */
-  def findMoves(position: Position): Set[Position]
+  def setPiece(position: Position, piece: Piece): Unit
 
   /**
-   * Performs the move by a piece on the board.
-   * @param move The [[Move]] to be executed
+   * Updates the chess board removing the piece at the specified position.
+   * @param position the specified position
    */
-  def move(move: Move): Unit
+  def removePiece(position: Position): Unit
 
-/** Factory for [[ChessBoard]] instances. */
+  /**
+   * Updates the chess board applying the specified updates.
+   * @param updates a list of updates, each mapping a certain position to a new piece,
+   *                or an empty optional if the piece has to be removed from that position
+   * @example
+   * {{{
+   *   chessBoard.update(
+   *     Position(A, _5) -> Pawn(),
+   *     Position(B, _8) -> None,
+   *     Position(E, _3) -> Knight(),
+   *   )
+   * }}}
+   */
+  def update(updates: (Position, Option[Piece])*): Unit =
+    updates.foreach {
+      case (position, Some(piece)) => setPiece(position, piece)
+      case (position, _)           => removePiece(position)
+    }
+
+/** Companion object of [[ChessBoard]]. */
 object ChessBoard:
+  export io.github.chess.model.ChessBoardBuilder.*
+
+  /** The length of the edges of the chess board. */
+  val Size: Int = 8
+
+  /** The total number of positions in the chess board. */
+  val NumberOfPositions: Int = ChessBoard.Size * ChessBoard.Size
+
+  /** All the possible positions in the chess board. */
+  lazy val Positions: Iterable[Position] =
+    for
+      i <- 0 until ChessBoard.Size
+      j <- 0 until ChessBoard.Size
+    yield (i, j)
+
+  /** Alias for [[ChessBoard.empty]]. */
+  def apply(): ChessBoard = ChessBoard.empty
 
   /**
-   * Creates a new Chess Board.
-   * @return a new [[ChessBoard]]
+   * @param builderConfiguration the context of the specified configuration
+   * @return a custom chess board initialized using a builder with the specified configuration
    */
-  def apply(vertx: Vertx): ChessBoard = ChessBoardImpl(vertx)
+  def apply(builderConfiguration: ChessBoardBuilder ?=> ChessBoardBuilder): ChessBoard =
+    ChessBoardBuilder.configure(builderConfiguration).build
 
-  private case class ChessBoardImpl(private val vertx: Vertx) extends ChessBoard:
-    import scala.collection.immutable.HashMap
+  /** @return an empty chess board with no pieces on top of it */
+  def empty: ChessBoard = BasicChessBoard()
 
-    private var whitePieces: Map[Position, Piece] =
-      Map.empty + ((Position(File.A, Rank._2), Pawn()))
-    private var blackPieces: Map[Position, Piece] = HashMap()
-    private var currentlyPlayingTeam = Team.WHITE
+  /** @return a chess board initialized for a standard game of chess. */
+  def standard: ChessBoard = ChessBoard {
+    r | n | b | q | k | b | n | r
+    p | p | p | p | p | p | p | p
+    * | * | * | * | * | * | * | *
+    * | * | * | * | * | * | * | *
+    * | * | * | * | * | * | * | *
+    * | * | * | * | * | * | * | *
+    P | P | P | P | P | P | P | P
+    R | N | B | Q | K | B | N | R
+  }
 
-    override def pieces: Map[Position, Piece] = this.whitePieces ++ this.blackPieces
-
-    override def findMoves(position: Position): Set[Position] =
-      val team = playingTeam
-      val selectedPiece = team.get(position)
-      selectedPiece match
-        case Some(piece) => piece.findMoves(position)
-        case None        => Set.empty
-
-    override def move(move: Move): Unit =
-      if findPiece(move.from).isDefined then
-        val newTeam = this.applyMove(move)
-        this.currentlyPlayingTeam match
-          case WHITE => this.whitePieces = newTeam
-          case BLACK => this.blackPieces = newTeam
-        // TODO: changePlayingTeam()
-
-    private def playingTeam: Map[Position, Piece] = this.currentlyPlayingTeam match
-      case WHITE => this.whitePieces
-      case BLACK => this.blackPieces
-
-    private def changePlayingTeam(): Unit =
-      this.currentlyPlayingTeam = this.currentlyPlayingTeam.oppositeTeam
-      val endTurnEvent = EndTurnEvent(this.currentlyPlayingTeam)
-      vertx.eventBus().publish(endTurnEvent.address, endTurnEvent)
-
-    private def findPiece(pos: Position): Option[Piece] = playingTeam.get(pos)
-
-    private def applyMove(move: Move): Map[Position, Piece] =
-      val team = playingTeam
-      val pieceToMove = findPiece(move.from)
-      pieceToMove match
-        case Some(piece) => team - move.from + ((move.to, piece))
-        case None        => team
+  /** Basic implementation of a chess board. */
+  private case class BasicChessBoard(private var _pieces: Map[Position, Piece] = Map.empty)
+      extends ChessBoard:
+    override def pieces: Map[Position, Piece] = this._pieces
+    override def setPiece(position: Position, piece: Piece): Unit =
+      this._pieces += position -> piece
+    override def removePiece(position: Position): Unit = this._pieces -= position

--- a/chess/src/main/scala/io/github/chess/model/ChessBoardBuilder.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessBoardBuilder.scala
@@ -133,8 +133,11 @@ object ChessBoardBuilder:
     @targetName("nextRow")
     def **(using b: ChessBoardBuilder): ChessBoardBuilder = **()
 
-    /** Skip the next cells of the row, making them empty. */
-    @targetName("nextRow")
+    /**
+     * Skip the next cells of the row. Can be repeated multiple times.
+     * @param repeats the number of rows to skip, including this row
+     */
+    @targetName("nextRowRepeated")
     def **(repeats: Int = 1)(using b: ChessBoardBuilder): ChessBoardBuilder = b - repeats
 
     extension (self: ChessBoardBuilder)

--- a/chess/src/main/scala/io/github/chess/model/ChessBoardBuilder.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessBoardBuilder.scala
@@ -1,0 +1,142 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.model
+
+import io.github.chess.util.option.OptionExtension.given
+import io.github.chess.model.ChessBoard
+import io.github.chess.util.exception.Require
+
+import scala.annotation.targetName
+
+/** Builder of a chess board. */
+class ChessBoardBuilder:
+  private val chessBoard: ChessBoard = ChessBoard.empty
+  private var indexOfNextCell = ChessBoardBuilder.MinIndex
+
+  /**
+   * Place the specified piece in the next cell of the chess board. <br\>
+   * The chess board is built progressively from the top-left corner to the bottom-right corner,
+   * first from left to right and then from top to bottom. <br\>
+   * Subsequent calls to this method will automatically consider the next cell to fill.
+   * @param piece the specified piece. If the piece is an empty optional, the cell will remain empty
+   * @return this
+   * @throws IllegalStateException if this method is called when all the cells of the chess board have already been set
+   */
+  def setNextCell(piece: Option[Piece]): this.type =
+    Require.state(
+      this.indexOfNextCell <= ChessBoardBuilder.MaxIndex,
+      s"Tried to set the ${this.indexOfNextCell + 1}th position out of ${ChessBoard.NumberOfPositions} positions. "
+    )
+    this.chessBoard.update(this.nextPosition -> piece)
+    this.indexOfNextCell += 1
+    this
+
+  /** Alias for [[ChessBoardBuilder.setNextCell]]. */
+  @targetName("setNextCellAlias")
+  def +(piece: Option[Piece]): this.type = this.setNextCell(piece)
+
+  /**
+   * Skip the next cells of the current row. Can be repeated multiple times.
+   * @param repeats the number of rows to skip, including the current row
+   * @return this
+   */
+  def nextRow(repeats: Int = 1): this.type = repeats match
+    case 0 => this
+    case n =>
+      this.indexOfNextCell += ChessBoard.Size - this.indexOfNextCell % ChessBoard.Size
+      nextRow(n - 1)
+
+  /** Alias for [[ChessBoardBuilder.nextRow]]. */
+  @targetName("nextRowAlias")
+  def -(repeats: Int = 1): this.type = nextRow(repeats)
+
+  /** @return the position of the next cell to fill */
+  private def nextPosition: Position = (
+    this.indexOfNextCell % ChessBoard.Size,
+    ChessBoard.Size - 1 - this.indexOfNextCell / ChessBoard.Size
+  )
+
+  /**
+   * @return the chess board initialized by this builder
+   * @note all the cells that are not filled before the call to this method will be considered
+   *       to be empty
+   */
+  def build: ChessBoard = this.chessBoard
+
+/** Companion object of [[ChessBoardBuilder]]. */
+object ChessBoardBuilder:
+  export io.github.chess.model.ChessBoardBuilder.DSL.*
+
+  /** The starting index of a [[ChessBoardBuilder]]. */
+  private val MinIndex = 0
+
+  /** The last index of a [[ChessBoardBuilder]]. */
+  private val MaxIndex = ChessBoard.NumberOfPositions - 1
+
+  /**
+   * @param configuration the context of the specified configuration
+   * @return a builder configured with the specified configuration
+   */
+  def configure(configuration: ChessBoardBuilder ?=> ChessBoardBuilder): ChessBoardBuilder =
+    given newBuilder: ChessBoardBuilder = ChessBoardBuilder()
+    configuration
+
+  /** A DSL definition for a [[ChessBoardBuilder]]. */
+  object DSL:
+    // TODO: white pieces
+    /** A white pawn. */
+    def P(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A white knight. */
+    def N(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A white bishop. */
+    def B(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A white rook. */
+    def R(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A white queen. */
+    def Q(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A white king. */
+    def K(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    // TODO: black pieces
+    /** A black pawn. */
+    def p(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A black knight. */
+    def n(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A black bishop. */
+    def b(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A black rook. */
+    def r(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A black queen. */
+    def q(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** A black king. */
+    def k(using b: ChessBoardBuilder): ChessBoardBuilder = b + Pawn()
+
+    /** An empty cell in the chess board. */
+    @targetName("emptyCell")
+    def *(using b: ChessBoardBuilder): ChessBoardBuilder = b + None
+
+    /** Skip the next cells of the row, making them empty. */
+    @targetName("nextRow")
+    def **(using b: ChessBoardBuilder): ChessBoardBuilder = **()
+
+    /** Skip the next cells of the row, making them empty. */
+    @targetName("nextRow")
+    def **(repeats: Int = 1)(using b: ChessBoardBuilder): ChessBoardBuilder = b - repeats
+
+    extension (self: ChessBoardBuilder)
+      /** DSL separator for chess pieces. */
+      @targetName("separator") def |(b: ChessBoardBuilder): ChessBoardBuilder = b

--- a/chess/src/main/scala/io/github/chess/model/ChessGame.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessGame.scala
@@ -17,7 +17,7 @@ import io.vertx.core.{Future, Handler, Vertx}
  * @param vertx the vertx where this game will be deployed
  */
 class ChessGame(private val vertx: Vertx) extends ChessPort:
-  private val state: ChessGameStatus = ChessGameStatus(ChessBoard.standard)
+  private val state: ChessGameStatus = ChessGameStatus()
 
   override def getState: Future[ChessGameStatus] =
     Future.succeededFuture(this.state)

--- a/chess/src/main/scala/io/github/chess/model/ChessGame.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessGame.scala
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.model
+
+import io.github.chess.util.option.OptionExtension.anyToOptionOfAny
+import io.github.chess.ports.ChessPort
+import io.github.chess.events.Event
+import io.vertx.core.eventbus.Message
+import io.vertx.core.{Future, Handler, Vertx}
+
+/**
+ * A game of chess.
+ * @param vertx the vertx where this game will be deployed
+ */
+class ChessGame(private val vertx: Vertx) extends ChessPort:
+  private val state: ChessGameStatus = ChessGameStatus(ChessBoard.standard)
+
+  override def getState: Future[ChessGameStatus] =
+    Future.succeededFuture(this.state)
+
+  override def findMoves(position: Position): Future[Set[Move]] =
+    Future.succeededFuture(
+      // TODO: replace this placeholder set of moves by using movement rules...
+      ChessBoard.Positions.filter(_ != position).map(to => Move(position, to)).toSet
+    )
+
+  override def applyMove(move: Move): Future[Unit] =
+    Future.succeededFuture(
+      move match
+        // TODO: add other move types before this clause (i.e. CaptureMove, PromotionMove...)
+        case m: Move =>
+          this.state.chessBoard.pieces.get(m.from).foreach { movingPiece =>
+            this.state.chessBoard.update(
+              m.from -> None,
+              m.to -> movingPiece
+            )
+          }
+    )
+
+  override def subscribe[T <: Event](address: String, handler: Handler[Message[T]]): Future[Unit] =
+    Future.succeededFuture(vertx.eventBus().consumer(address, handler))
+
+//  TODO consider this logic inside the chess game component
+//  private case class ChessBoardImpl(private val vertx: Vertx) extends ChessBoard:
+//    import scala.collection.immutable.HashMap
+//
+//    private var whitePieces: Map[Position, Piece] =
+//      Map.empty + ((Position(File.A, Rank._2), Pawn()))
+//    private var blackPieces: Map[Position, Piece] = HashMap()
+//    private var currentlyPlayingTeam = Team.WHITE
+//
+//    override def pieces: Map[Position, Piece] = this.whitePieces ++ this.blackPieces
+//
+
+//
+//    override def move(move: Move): Unit =
+//      if findPiece(move.from).isDefined then
+//        val newTeam = this.applyMove(move)
+//        this.currentlyPlayingTeam match
+//          case WHITE => this.whitePieces = newTeam
+//          case BLACK => this.blackPieces = newTeam
+//        // TODO: changePlayingTeam()
+//
+//    private def playingTeam: Map[Position, Piece] = this.currentlyPlayingTeam match
+//      case WHITE => this.whitePieces
+//      case BLACK => this.blackPieces
+//
+//    private def changePlayingTeam(): Unit =
+//      this.currentlyPlayingTeam = this.currentlyPlayingTeam.oppositeTeam
+//      val endTurnEvent = EndTurnEvent(this.currentlyPlayingTeam)
+//      vertx.eventBus().publish(endTurnEvent.address, endTurnEvent)
+//
+//    private def findPiece(pos: Position): Option[Piece] = playingTeam.get(pos)
+//
+//    private def applyMove(move: Move): Map[Position, Piece] =
+//      val team = playingTeam
+//      val pieceToMove = findPiece(move.from)
+//      pieceToMove match
+//        case Some(piece) => team - move.from + ((move.to, piece))
+//        case None        => team

--- a/chess/src/main/scala/io/github/chess/model/ChessGameStatus.scala
+++ b/chess/src/main/scala/io/github/chess/model/ChessGameStatus.scala
@@ -30,7 +30,7 @@ object ChessGameStatus:
    * @return a state
    */
   def apply(
-      chessBoard: ChessBoard,   //TODO: add default argument for standard chess board initial disposition
+      chessBoard: ChessBoard = ChessBoard.standard,
       history: ChessGameHistory = ChessGameHistory(),
       initialTurn: Team = Team.WHITE
   ): ChessGameStatus =

--- a/chess/src/main/scala/io/github/chess/ports/ChessPort.scala
+++ b/chess/src/main/scala/io/github/chess/ports/ChessPort.scala
@@ -7,53 +7,43 @@
 package io.github.chess.ports
 
 import io.github.chess.events.Event
-import io.github.chess.model.{ChessBoard, Move, Position}
+import io.github.chess.model.{ChessGameStatus, Move, Position}
 import io.vertx.core.eventbus.Message
-import io.vertx.core.{Handler, Vertx}
+import io.vertx.core.{Future, Handler}
 
-/** Represents the controller of the game. */
+/** Represents the contract of a chess engine service. */
 trait ChessPort:
 
   // TODO inserire gameConfiguration parameter e pensare a cosa ritornare
   // (discutere se la view crea subito il modello e cambia la gameConfiguration con i vari input dell'utente)
-  // def createGame(): Map[Position, Piece] = chessBoard.pieces
-
-  /**
-   * Returns all moves available from a particular position.
-   * @param position starting [[Position]]
-   * @return a [[Set]] of [[Position]]
-   */
-  def findMoves(position: Position): Set[Position]
-
-  /**
-   * Moves a piece from a position to another position.
-   * @param from starting [[Position]]
-   * @param to target [[Position]]
-   */
-  def move(from: Position, to: Position): Unit
+  // def createGame(gc: GameConfiguration): ChessGameStatus
 
   // TODO inserire player parameter
-  //  def surrender(): Unit = ???
+  // def surrender(p: Player): Unit = ???
 
+  /** @return a future containing the state of the game of chess */
+  def getState: Future[ChessGameStatus]
+
+  /**
+   * @param position the specified position
+   * @return a future containing all the possible moves that are available
+   *         from the specified position
+   */
+  def findMoves(position: Position): Future[Set[Move]]
+
+  /**
+   * Applies the specified move to this game of chess.
+   * @param move the specified move
+   * @return a future that completes when the move has been applied
+   */
+  def applyMove(move: Move): Future[Unit]
+
+  // TODO: reason about changing it to subscribe[T <: Event](handler: (Event) => Unit)
   /**
    * Subscribes an handler to a particular event.
    * @param address address to subscribe on
    * @param handler [[Handler]] to inform when the event is published
    * @tparam T type parameter of the event extending superclass [[Event]]
+   * @return a future that completes when the subscription has been registered
    */
-  def subscribe[T <: Event](address: String, handler: Handler[Message[T]]): Unit
-
-object ChessPort:
-
-  def apply(vertx: Vertx): ChessPort = ChessPortImpl(vertx)
-
-  private case class ChessPortImpl(private val vertx: Vertx) extends ChessPort:
-
-    private val chessBoard = ChessBoard(vertx)
-
-    override def findMoves(position: Position): Set[Position] = chessBoard.findMoves(position)
-
-    override def move(from: Position, to: Position): Unit = chessBoard.move(Move(from, to))
-
-    override def subscribe[T <: Event](address: String, handler: Handler[Message[T]]): Unit =
-      vertx.eventBus().consumer(address, handler)
+  def subscribe[T <: Event](address: String, handler: Handler[Message[T]]): Future[Unit]

--- a/chess/src/main/scala/io/github/chess/services/ChessService.scala
+++ b/chess/src/main/scala/io/github/chess/services/ChessService.scala
@@ -6,20 +6,21 @@
  */
 package io.github.chess.services
 
-import io.github.chess.adapters.ChessAdapter
+import io.github.chess.adapters.ChessLocalAdapter
 import io.github.chess.ports.ChessPort
 import io.vertx.core.{AbstractVerticle, Promise}
 
 /** Service to instantiates all the adapters. */
 class ChessService(private val chessPort: ChessPort) extends AbstractVerticle:
 
-  private var _chessAdapter: Option[ChessAdapter] = None
+  private var _chessAdapter: Option[ChessLocalAdapter] = None
 
   override def start(startPromise: Promise[Void]): Unit =
-    _chessAdapter = Some(ChessAdapter(chessPort))
+    _chessAdapter = Some(ChessLocalAdapter(chessPort))
+    startPromise.complete()
 
   /**
-   * Returns the [[ChessAdapter]].
-   * @return the [[ChessAdapter]]
+   * Returns the [[ChessLocalAdapter]].
+   * @return the [[ChessLocalAdapter]]
    */
-  def chessAdapter: Option[ChessAdapter] = _chessAdapter
+  def localAdapter: Option[ChessLocalAdapter] = _chessAdapter

--- a/chess/src/main/scala/io/github/chess/util/exception/Require.scala
+++ b/chess/src/main/scala/io/github/chess/util/exception/Require.scala
@@ -1,0 +1,27 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.util.exception
+
+/** Utility for throwing exceptions. */
+object Require:
+  /**
+   * Throws the specified [[Throwable]] if the specified condition is not met.
+   *
+   * @param condition the specified condition
+   * @param throwable the specified throwable
+   * @throws Throwable if the specified condition is not met
+   */
+  def condition(condition: Boolean, throwable: Throwable): Unit =
+    if (!condition) throw throwable
+
+  /** As [[Require.condition]] but throws an [[IllegalArgumentException]] with the specified message. */
+  def input(argumentCondition: Boolean, errorMessage: String): Unit =
+    Require.condition(argumentCondition, IllegalArgumentException(errorMessage))
+
+  /** As [[Require.condition]] but throws an [[IllegalStateException]] with the specified message. */
+  def state(stateCondition: Boolean, errorMessage: String): Unit =
+    Require.condition(stateCondition, IllegalStateException(errorMessage))

--- a/chess/src/main/scala/io/github/chess/util/option/OptionExtension.scala
+++ b/chess/src/main/scala/io/github/chess/util/option/OptionExtension.scala
@@ -1,0 +1,23 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.util.option
+
+/** Extension for the [[Option]] class. */
+object OptionExtension:
+  /**
+   * Implicitly transforms an object to an optional containing that object.
+   * @tparam T the type of object
+   * @return an optional containing the specified object
+   */
+  given anyToOptionOfAny[T]: Conversion[T, Option[T]] = Option(_)
+
+  extension [T](self: Option[T])
+    /**
+     * @param t the specified throwable
+     * @return the content of this optional or throws the specified throwable if this optional is empty
+     */
+    def getOrThrow(t: Throwable): T = self.getOrElse { throw t }

--- a/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplication.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplication.scala
@@ -6,32 +6,41 @@
  */
 package io.github.chess.viewcontroller
 
+import io.github.chess.ports.ChessPort
+import io.github.chess.viewcontroller.ChessApplicationContext.ChessApplicationContextBuilder
 import io.github.chess.viewcontroller.fxcomponents.pages.MainMenuPage
 import scalafx.Includes.*
 import scalafx.application.{JFXApp3, Platform}
 import scalafx.application.JFXApp3.PrimaryStage
 import scalafx.stage.Stage
 
-/** Graphical user interface of Chess Game. */
-object ChessGameInterface extends JFXApp3:
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
-  /** @return the primary stage of this application as a given instance. */
-  given mainStage: Stage = this.mainStageSupplier()
-  private val mainStageSupplier: () => Stage = () => this.stage
+/** Graphical user interface of Chess Game. */
+object ChessApplication extends JFXApp3:
+  private val contextBuilder: ChessApplicationContextBuilder = ChessApplicationContext.builder
+
+  /** @return the context of this application as a given instance. */
+  given applicationContext: ChessApplicationContext = this.contextBuilder.build
 
   /**
    * Launch the graphical user interface with the specified arguments.
    * @param args the specified arguments
    */
-  def launch(args: Array[String]): Unit = this.main(args)
+  def launch(chessEngineProxy: ChessPort)(args: Array[String]): Unit =
+    Future {
+      this.contextBuilder.setChessEngineProxy(chessEngineProxy)
+      this.main(args)
+    }
 
   override def start(): Unit =
     stageConfiguration()
-    MainMenuPage()
-
+    MainMenuPage(stage)
   override def stopApp(): Unit = System.exit(0)
 
   /** Configure the stage of the application. */
   private def stageConfiguration(): Unit =
     this.stage = new PrimaryStage():
       title = "Chess Game"
+    this.contextBuilder.setPrimaryStage(this.stage)

--- a/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplicationComponent.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplicationComponent.scala
@@ -4,10 +4,12 @@
  *
  * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
  */
-package io.github.chess.adapters
+package io.github.chess.viewcontroller
 
 import io.github.chess.ports.ChessPort
-import io.vertx.core.Vertx
+import scalafx.stage.Stage
 
-/** Helps the view communicate with the chess game. */
-class ChessAdapter(override val port: ChessPort) extends AbstractAdapter[ChessPort]
+/** Component of this chess application, either logical or graphical. */
+trait ChessApplicationComponent:
+  /** @return the context of this application */
+  protected def context: ChessApplicationContext

--- a/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplicationContext.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/ChessApplicationContext.scala
@@ -1,0 +1,75 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.viewcontroller
+
+import io.github.chess.util.option.OptionExtension.getOrThrow
+import io.github.chess.ports.ChessPort
+import scalafx.stage.Stage
+
+/** The context of this application. */
+trait ChessApplicationContext:
+  /** @return the main stage where this application is displayed */
+  def primaryStage: Stage
+
+  /** @return the proxy used to interact with the chess engine service required by this application */
+  def chessEngineProxy: ChessPort
+
+/** Companion object of [[ChessApplicationContext]]. */
+object ChessApplicationContext:
+  /**
+   * @param primaryStage the main stage where this application is displayed
+   * @param chessEngineProxy the proxy used to interact with the chess engine service required by this application
+   * @return a new context for this application
+   */
+  def apply(primaryStage: Stage, chessEngineProxy: ChessPort): ChessApplicationContext =
+    BasicChessApplicationContext(primaryStage, chessEngineProxy)
+
+  /** @return a builder for [[ChessApplicationContext]]s */
+  def builder: ChessApplicationContextBuilder = ChessApplicationContextBuilder()
+
+  /** Basic implementation of a [[ChessApplicationContext]]. */
+  private case class BasicChessApplicationContext(
+      override val primaryStage: Stage,
+      override val chessEngineProxy: ChessPort
+  ) extends ChessApplicationContext
+
+  /** Builder for [[ChessApplicationContext]]. */
+  case class ChessApplicationContextBuilder private[ChessApplicationContext] ():
+    private var primaryStage: Option[Stage] = Option.empty
+    private var chessEngineProxy: Option[ChessPort] = Option.empty
+
+    /**
+     * Set the main stage where this application is displayed to the specified stage.
+     * @param primaryStage the specified stage
+     * @return this
+     */
+    def setPrimaryStage(primaryStage: Stage): this.type =
+      this.primaryStage = Option(primaryStage)
+      this
+
+    /**
+     * Set the proxy used to interact with the chess engine service required by this application to the specified proxy.
+     * @param chessEngineProxy the specified proxy
+     * @return this
+     */
+    def setChessEngineProxy(chessEngineProxy: ChessPort): this.type =
+      this.chessEngineProxy = Option(chessEngineProxy)
+      this
+
+    /**
+     * @return a new application context created using the configuration of this builder
+     * @throws IllegalStateException if any of the required configuration is missing
+     */
+    def build: ChessApplicationContext =
+      ChessApplicationContext(
+        this.primaryStage.getOrThrow {
+          IllegalStateException("Primary stage not set")
+        },
+        this.chessEngineProxy.getOrThrow {
+          IllegalStateException("Chess engine proxy not set")
+        }
+      )

--- a/chess/src/main/scala/io/github/chess/viewcontroller/ChessLocalProxy.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/ChessLocalProxy.scala
@@ -1,0 +1,16 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.viewcontroller
+
+import io.github.chess.ports.ChessPort
+
+/**
+ * A proxy for interacting with a chess engine service through local interactions.
+ * @param port the local port of the chess engine service
+ */
+case class ChessLocalProxy(private val port: ChessPort) extends ChessPort:
+  export port.*

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/GameConfigurationPageController.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/GameConfigurationPageController.scala
@@ -6,7 +6,8 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.controllers
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.template.FXMLController
 import io.github.chess.viewcontroller.fxcomponents.pages.{GamePage, MainMenuPage}
 import javafx.scene.control.Button
@@ -18,13 +19,15 @@ import java.util.ResourceBundle
  * Controller of the game configuration page of the application.
  * @param stage the stage where the application is displayed.
  */
-class GameConfigurationPageController()(using override protected val stage: Stage)
-    extends FXMLController:
+class GameConfigurationPageController(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLController
+    with ChessApplicationComponent:
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var startGameButton: Button = _
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var backButton: Button = _
 
   override def initialize(url: URL, resourceBundle: ResourceBundle): Unit =
-    this.startGameButton.onMouseClicked = _ => GamePage()
-    this.backButton.onMouseClicked = _ => MainMenuPage()
+    this.startGameButton.onMouseClicked = _ => GamePage(stage)
+    this.backButton.onMouseClicked = _ => MainMenuPage(stage)

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/GamePageController.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/GamePageController.scala
@@ -6,7 +6,8 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.controllers
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.ChessBoardController
 import io.github.chess.viewcontroller.fxcomponents.controllers.template.FXMLController
 import io.github.chess.viewcontroller.fxcomponents.pages.MainMenuPage
@@ -20,7 +21,10 @@ import java.util.ResourceBundle
  * Controller of the game page of the application.
  * @param stage the stage where the application is displayed.
  */
-class GamePageController()(using override protected val stage: Stage) extends FXMLController:
+class GamePageController(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLController
+    with ChessApplicationComponent:
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var surrenderButton: Button = _
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
@@ -33,8 +37,8 @@ class GamePageController()(using override protected val stage: Stage) extends FX
   private var lastMoveText: TextField = _
 
   override def initialize(url: URL, resourceBundle: ResourceBundle): Unit =
-    val chessBoardController = ChessBoardController.fromGridPane(this.chessBoardGridPane)
-    this.surrenderButton.onMouseClicked = _ => MainMenuPage()
+    val chessBoardController = ChessBoardController.fromGridPane(this.chessBoardGridPane)(stage)
+    this.surrenderButton.onMouseClicked = _ => MainMenuPage(stage)
 
     // TODO: get access to the proxy for the chess engine service (as a given constructor parameter?)
     // TODO: subscribe to game state changes, calling the repaint of the chess board controller

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/MainMenuController.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/controllers/MainMenuController.scala
@@ -6,7 +6,8 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.controllers
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.template.FXMLController
 import io.github.chess.viewcontroller.fxcomponents.pages.GameConfigurationPage
 import javafx.scene.control.Button
@@ -19,12 +20,15 @@ import java.util.ResourceBundle
  * Controller of the main menu of the application.
  * @param stage the stage where the application is displayed.
  */
-class MainMenuController()(using override protected val stage: Stage) extends FXMLController:
+class MainMenuController(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLController
+    with ChessApplicationComponent:
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var newGameButton: Button = _
   @FXML @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var exitButton: Button = _
 
   override def initialize(url: URL, resourceBundle: ResourceBundle): Unit =
-    this.newGameButton.onMouseClicked = _ => GameConfigurationPage()
+    this.newGameButton.onMouseClicked = _ => GameConfigurationPage(stage)
     this.exitButton.onMouseClicked = _ => Platform.exit()

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/GameConfigurationPage.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/GameConfigurationPage.scala
@@ -6,9 +6,9 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.pages
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.GameConfigurationPageController
-import io.github.chess.viewcontroller.fxcomponents.controllers.template.Controller
 import io.github.chess.viewcontroller.fxcomponents.pages.template.{ApplicablePage, FXMLPage}
 import scalafx.stage.Stage
 
@@ -16,6 +16,8 @@ import scalafx.stage.Stage
  * The page that allows to configure a game before starting it.
  * @param stage the stage where the application is displayed
  */
-case class GameConfigurationPage()(using override protected val stage: Stage)
-    extends FXMLPage(GameConfigurationPageController(), "pages/game-configuration-page")
+case class GameConfigurationPage(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLPage(GameConfigurationPageController(stage), "pages/game-configuration-page")
     with ApplicablePage
+    with ChessApplicationComponent

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/GamePage.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/GamePage.scala
@@ -6,9 +6,9 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.pages
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.GamePageController
-import io.github.chess.viewcontroller.fxcomponents.controllers.template.Controller
 import io.github.chess.viewcontroller.fxcomponents.pages.template.{ApplicablePage, FXMLPage}
 import scalafx.stage.Stage
 
@@ -16,6 +16,8 @@ import scalafx.stage.Stage
  * The page that shows the game developing in time.
  * @param stage the stage where the application is displayed
  */
-case class GamePage()(using override protected val stage: Stage)
-    extends FXMLPage(GamePageController(), "pages/game-page")
+case class GamePage(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLPage(GamePageController(stage), "pages/game-page")
     with ApplicablePage
+    with ChessApplicationComponent

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/MainMenuPage.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/MainMenuPage.scala
@@ -6,9 +6,9 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.pages
 
-import io.github.chess.viewcontroller.ChessGameInterface.given
+import io.github.chess.viewcontroller.ChessApplication.given
+import io.github.chess.viewcontroller.{ChessApplicationComponent, ChessApplicationContext}
 import io.github.chess.viewcontroller.fxcomponents.controllers.MainMenuController
-import io.github.chess.viewcontroller.fxcomponents.controllers.template.Controller
 import io.github.chess.viewcontroller.fxcomponents.pages.template.{ApplicablePage, FXMLPage}
 import scalafx.stage.Stage
 
@@ -16,6 +16,8 @@ import scalafx.stage.Stage
  * Main menu of the application.
  * @param stage the stage where the application is displayed
  */
-case class MainMenuPage()(using override protected val stage: Stage)
-    extends FXMLPage(MainMenuController(), "pages/main-menu")
+case class MainMenuPage(override protected val stage: Stage)(using
+    override protected val context: ChessApplicationContext
+) extends FXMLPage(MainMenuController(stage), "pages/main-menu")
     with ApplicablePage
+    with ChessApplicationComponent

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/components/CellView.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/components/CellView.scala
@@ -7,11 +7,9 @@
 package io.github.chess.viewcontroller.fxcomponents.pages.components
 
 import io.github.chess.model.Position
-import io.github.chess.model.Position.given
 import io.github.chess.util.number.NumberExtension.*
 import io.github.chess.viewcontroller.configuration.InterfaceConfiguration.{Colors, Images}
 import io.github.chess.viewcontroller.fxcomponents.pages.components.CellView.Layer
-import io.github.chess.viewcontroller.fxcomponents.controllers.template.Controller
 import io.github.chess.viewcontroller.fxcomponents.pages.components.CellView.{
   MOVE_EFFECT_RESCALING,
   PIECE_RESCALING
@@ -27,10 +25,8 @@ import scalafx.stage.Stage
 /**
  * Handles the view of a cell of the chess board view.
  * @param cell     the cell of the chess board view
- * @param stage    the stage where the application is displayed
  */
-case class CellView(cell: GridCell[Pane])(using override protected val stage: Stage)
-    extends Controller:
+case class CellView(cell: GridCell[Pane]):
   export cell.content.setOnMouseClicked
 
   private var layers: Map[Layer, ImageView] = Map()

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/template/FXMLPage.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxcomponents/pages/template/FXMLPage.scala
@@ -6,6 +6,7 @@
  */
 package io.github.chess.viewcontroller.fxcomponents.pages.template
 
+import io.github.chess.util.option.OptionExtension.getOrThrow
 import io.github.chess.viewcontroller.fxcomponents.controllers.template.FXMLController
 import io.github.chess.viewcontroller.fxcomponents.pages.template.{Page, PageWithController}
 import javafx.fxml.FXMLLoader
@@ -53,8 +54,8 @@ object FXMLPage:
    * @return an url corresponding to the fxml resource identified by the specified path
    */
   private def fxmlURLfromPath(localPath: String): URL =
-    Option(this.getClass.getResource(s"/$localPath.fxml")).getOrElse {
-      throw IllegalArgumentException(
+    Option(this.getClass.getResource(s"/$localPath.fxml")).getOrThrow {
+      IllegalArgumentException(
         "Could not load the specified resource. Try with a different path."
       )
     }

--- a/chess/src/main/scala/io/github/chess/viewcontroller/fxutils/FXUtils.scala
+++ b/chess/src/main/scala/io/github/chess/viewcontroller/fxutils/FXUtils.scala
@@ -6,6 +6,7 @@
  */
 package io.github.chess.viewcontroller.fxutils
 
+import io.github.chess.model.{File, Rank, Position}
 import javafx.scene.Node
 import scalafx.Includes.*
 import scalafx.geometry.Insets
@@ -15,6 +16,14 @@ import scalafx.scene.paint.Color
 
 /** Utility class for ScalaFX. */
 object FXUtils:
+
+  /**
+   * @return a position in the chess board, given a pair of coordinates considering the
+   *         view reference system.
+   */
+  given convertViewReferenceSystemToPosition: Conversion[(Int, Int), Position] = (x, y) =>
+    Position(File.fromOrdinal(x), Rank.fromOrdinal(Rank.values.length - y - 1))
+
   /**
    * Change the color of the specified region to the specified color.
    * @param region the specified region

--- a/chess/src/test/scala/io/github/chess/model/ChessBoardBuilderDSLSpec.scala
+++ b/chess/src/test/scala/io/github/chess/model/ChessBoardBuilderDSLSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.model
+
+import io.github.chess.util.option.OptionExtension.anyToOptionOfAny
+import io.github.chess.model.{ChessBoardBuilder, ChessBoard}
+import io.github.chess.model.ChessBoardBuilder.*
+import io.github.chess.AbstractSpec
+
+/** Test suit for the [[ChessBoardBuilder]]. */
+class ChessBoardBuilderDSLSpec extends AbstractSpec:
+
+  "The DSL of a chess board builder" should "provide a working syntax for faster configuration" in {
+    val chessBoardBuilder: ChessBoardBuilder = ChessBoardBuilder.configure {
+      p | p | p | p | p | p | p | p
+      p | p | p | p | p | p | p | p
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      P | P | P | P | P | P | P | P
+      P | P | P | P | P | P | P | P
+    }
+    ChessBoard.Positions
+      .map { position => position -> chessBoardBuilder.build.pieces.get(position) }
+      .foreach {
+        case (position, piece) if Set(Rank._8, Rank._7)(position.rank) =>
+          piece shouldBe defined
+          piece.foreach(_ shouldEqual Pawn( /*TODO black*/ ))
+        case (position, piece) if Set(Rank._1, Rank._2)(position.rank) =>
+          piece shouldBe defined
+          piece.foreach(_ shouldEqual Pawn( /*TODO white*/ ))
+        case (_, piece) => piece shouldNot be(defined)
+      }
+  }
+
+  it should "provide a syntax for defining empty rows quickly" in {
+    val chessBoardBuilder: ChessBoardBuilder = ChessBoardBuilder.configure {
+      p | p | * | * | p | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      p | p | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      P | P | P | * | * | * | * | *
+    }
+    // Note: semicolons are actually required BEFORE ** if it is used in a line by itself (** is infix for scala)
+    val otherChessBoardBuilder: ChessBoardBuilder = ChessBoardBuilder.configure {
+      p | p | * | * | p | **;
+      **;
+      **;
+      p | p | **;
+      **;
+      **;
+      **;
+      P | P | P | **;
+    }
+    // Note: this is more compact and does not require any semicolon
+    val yetAnotherChessBoardBuilder: ChessBoardBuilder = ChessBoardBuilder.configure {
+      p | p | * | * | p | ** { 3 }
+      p | p | ** { 4 }
+      P | P | P | **
+    }
+    chessBoardBuilder.build shouldEqual otherChessBoardBuilder.build
+    chessBoardBuilder.build shouldEqual yetAnotherChessBoardBuilder.build
+  }

--- a/chess/src/test/scala/io/github/chess/model/ChessBoardBuilderSpec.scala
+++ b/chess/src/test/scala/io/github/chess/model/ChessBoardBuilderSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.model
+
+import io.github.chess.util.option.OptionExtension.anyToOptionOfAny
+import io.github.chess.model.{ChessBoard, ChessBoardBuilder}
+import io.github.chess.model.ChessBoardBuilder.*
+import io.github.chess.AbstractSpec
+
+import java.lang.IllegalStateException
+
+/** Test suit for the [[ChessBoardBuilder]]. */
+class ChessBoardBuilderSpec extends AbstractSpec:
+
+  "A chess board builder" should "produce an empty chess board if not configured" in {
+    ChessBoardBuilder().build shouldEqual ChessBoard.empty
+  }
+
+  it should "produce the specified chess board if configured" in {
+    val chessBoardBuilder =
+      ChessBoardBuilder()
+        .setNextCell(whitePawn)
+        .setNextCell(whitePawn)
+        .setNextCell(None)
+        .setNextCell(blackPawn)
+        .nextRow()
+        .setNextCell(None)
+        .setNextCell(None)
+        .setNextCell(whitePawn)
+    chessBoardBuilder.build shouldEqual ChessBoard {
+      P | P | * | p | * | * | * | *
+      * | * | p | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+    }
+  }
+
+  it should "provide a lighter configuration syntax" in {
+    val chessBoardBuilder =
+      ChessBoardBuilder()
+        .nextRow()
+        .setNextCell(whitePawn)
+        .setNextCell(None)
+        .setNextCell(blackPawn)
+        .nextRow()
+        .nextRow()
+        .setNextCell(whitePawn)
+    val otherChessBoardBuilder =
+      ChessBoardBuilder()
+        - 1
+        + whitePawn
+        + None
+        + blackPawn
+        - 2
+        + whitePawn
+    chessBoardBuilder.build shouldEqual otherChessBoardBuilder.build
+  }
+
+  it should s"throw an illegal state exception when trying to fill more than ${ChessBoard.NumberOfPositions} cells" in {
+    val chessBoardBuilder = ChessBoardBuilder().nextRow(8)
+    an[IllegalStateException] should be thrownBy { chessBoardBuilder.setNextCell(whitePawn) }
+  }
+
+  /** @return a new white pawn */
+  private def whitePawn: Piece = Pawn( /*TODO white*/ )
+
+  /** @return a new black pawn */
+  private def blackPawn: Piece = Pawn( /*TODO black*/ )

--- a/chess/src/test/scala/io/github/chess/model/ChessBoardSpec.scala
+++ b/chess/src/test/scala/io/github/chess/model/ChessBoardSpec.scala
@@ -6,42 +6,71 @@
  */
 package io.github.chess.model
 
+import io.github.chess.util.option.OptionExtension.anyToOptionOfAny
+import io.github.chess.model.ChessBoard
+import io.github.chess.model.ChessBoard.*
 import io.github.chess.AbstractSpec
-import io.vertx.core.Vertx
 
 /** Test suit for the [[ChessBoard]]. */
 class ChessBoardSpec extends AbstractSpec:
+  val piece: Piece = Pawn()
+  val position: Position = Position(File.A, Rank._1)
+  val otherPiece: Piece = Pawn()
+  val otherPosition: Position = Position(File.A, Rank._8)
 
-  val pawnInitialPosition: Position = Position(File.A, Rank._2)
-  val pawnNextPosition: Position = pawnInitialPosition.rankUp()
-  val firstMove: Move = Move(pawnInitialPosition, pawnNextPosition)
-  val chessBoard: ChessBoard = ChessBoard(Vertx.vertx())
-
-  "The chess board" should "initially have a piece in the position a2" in {
-    chessBoard.pieces.get(pawnInitialPosition) should be(defined)
+  "A chess board" should s"have ${ChessBoard.NumberOfPositions} possible positions" in {
+    ChessBoard.Positions.size shouldEqual ChessBoard.NumberOfPositions
   }
 
-  it should "let you move its pawn from a2 to a3" in {
-    chessBoard.findMoves(pawnInitialPosition) should contain(pawnNextPosition)
+  it should s"have a total of ${ChessBoard.Size} columns (files)" in {
+    ChessBoard.Positions.groupBy(_.rank).foreach(_._2.size shouldEqual ChessBoard.Size)
   }
 
-  it should "see the new position of the pawn, after its move" in {
-    chessBoard.move(firstMove)
-    chessBoard.pieces.get(pawnInitialPosition) shouldNot be(defined)
-    chessBoard.pieces.get(pawnNextPosition) should be(defined)
+  it should s"have a total of ${ChessBoard.Size} rows (ranks)" in {
+    ChessBoard.Positions.groupBy(_.file).foreach(_._2.size shouldEqual ChessBoard.Size)
   }
 
-  // TODO refactor
-//  it should "forbid the player from moving the pieces of the opposite team" in {
-//    chessBoard.move(firstMove)
-//    chessBoard.pieces.get(pawnNextPosition) should be(defined)
-//    val thirdPosition = pawnNextPosition.rankUp()
-//    val secondMove = Move(pawnNextPosition, thirdPosition)
-//    chessBoard.move(secondMove)
-//    chessBoard.pieces.get(pawnNextPosition) should be(defined)
-//    chessBoard.pieces.get(thirdPosition) shouldNot be(defined)
-//  }
+  "An empty chess board" should "initially contain no pieces" in {
+    ChessBoard.empty.pieces shouldBe empty
+  }
 
-  "All the moves" should "be available from the same starting position" in {
-    all(chessBoard.findMoves(pawnInitialPosition)) should have(Symbol("from")(pawnInitialPosition))
+  it should "allow to place a piece on it" in {
+    val chessBoard: ChessBoard = ChessBoard.empty
+    chessBoard.setPiece(position, piece)
+    chessBoard.pieces(position) should be theSameInstanceAs piece
+  }
+
+  it should "allow to place more pieces on it" in {
+    val chessBoard: ChessBoard = ChessBoard.empty
+    chessBoard.setPiece(position, piece)
+    chessBoard.setPiece(otherPosition, otherPiece)
+    chessBoard.pieces(position) should be theSameInstanceAs piece
+    chessBoard.pieces(otherPosition) should be theSameInstanceAs otherPiece
+  }
+
+  it should "allow to replace a piece already present on it" in {
+    val chessBoard: ChessBoard = ChessBoard.empty
+    chessBoard.setPiece(position, piece)
+    chessBoard.update(position -> otherPiece)
+    chessBoard.pieces(position) should be theSameInstanceAs otherPiece
+  }
+
+  it should "allow to remove a piece already present on it" in {
+    val chessBoard: ChessBoard = ChessBoard.empty
+    chessBoard.setPiece(position, piece)
+    chessBoard.removePiece(position)
+    chessBoard.pieces.get(position) shouldNot be(defined)
+  }
+
+  "A chess board at the beginning of a chess game" should "abide to the standard configuration for the chess pieces" in {
+    ChessBoard.standard shouldEqual ChessBoard {
+      r | n | b | q | k | b | n | r
+      p | p | p | p | p | p | p | p
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      * | * | * | * | * | * | * | *
+      P | P | P | P | P | P | P | P
+      R | N | B | Q | K | B | N | R
+    }
   }

--- a/chess/src/test/scala/io/github/chess/model/ChessGameHistorySpec.scala
+++ b/chess/src/test/scala/io/github/chess/model/ChessGameHistorySpec.scala
@@ -23,25 +23,25 @@ class ChessGameHistorySpec extends AbstractSpec:
 
   "The history of moves in a chess game" should "be initially empty" in {
     val gameHistory: ChessGameHistory = ChessGameHistory()
-    gameHistory.all should be(empty)
+    gameHistory.all shouldBe empty
   }
 
   it should "remember the moves after they have been saved in it" in {
     val gameHistory: ChessGameHistory = ChessGameHistory()
     moves.foreach { move => gameHistory.save(piece, move) }
-    gameHistory.all should be(moves)
+    gameHistory.all shouldEqual moves
   }
 
   it should "remember the moves of different pieces after they have been saved in it" in {
     val gameHistory: ChessGameHistory = ChessGameHistory()
     moves.foreach { move => gameHistory.save(piece, move) }
     otherMoves.foreach { move => gameHistory.save(otherPiece, move) }
-    gameHistory.all should be(moves :++ otherMoves)
+    gameHistory.all shouldEqual moves :++ otherMoves
   }
 
   it should "allow to query the moves of a specific piece after they have been saved in it" in {
     val gameHistory: ChessGameHistory = ChessGameHistory()
     moves.foreach { move => gameHistory.save(piece, move) }
     otherMoves.foreach { move => gameHistory.save(otherPiece, move) }
-    gameHistory.ofPiece(otherPiece) should be(otherMoves)
+    gameHistory.ofPiece(otherPiece) shouldEqual otherMoves
   }

--- a/chess/src/test/scala/io/github/chess/model/ChessGameSpec.scala
+++ b/chess/src/test/scala/io/github/chess/model/ChessGameSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Cesario Jahrim Gabriele & Derevyanchenko Maxim & Felice Mirko & Kentpayeva Madina
+ *
+ * Full license description available at: https://github.com/jahrim/PPS-22-chess/blob/master/LICENSE
+ */
+package io.github.chess.model
+
+import io.github.chess.AbstractSpec
+
+class ChessGameSpec extends AbstractSpec
+
+/* TODO consider these tests
+ "The chess board" should "initially have a piece in the position a2" in {
+   chessBoard.pieces.get(pawnInitialPosition) should be(defined)
+ }
+
+ it should "let you move its pawn from a2 to a3" in {
+   chessBoard.findMoves(pawnInitialPosition) should contain(pawnNextPosition)
+ }
+
+ it should "see the new position of the pawn, after its move" in {
+   chessBoard.move(firstMove)
+   chessBoard.pieces.get(pawnInitialPosition) shouldNot be(defined)
+   chessBoard.pieces.get(pawnNextPosition) should be(defined)
+ }
+
+
+//  it should "forbid the player from moving the pieces of the opposite team" in {
+//    chessBoard.move(firstMove)
+//    chessBoard.pieces.get(pawnNextPosition) should be(defined)
+//    val thirdPosition = pawnNextPosition.rankUp()
+//    val secondMove = Move(pawnNextPosition, thirdPosition)
+//    chessBoard.move(secondMove)
+//    chessBoard.pieces.get(pawnNextPosition) should be(defined)
+//    chessBoard.pieces.get(thirdPosition) shouldNot be(defined)
+//  }
+
+ "All the moves" should "be available from the same starting position" in {
+   all(chessBoard.findMoves(pawnInitialPosition)) should have(Symbol("from")(pawnInitialPosition))
+ }
+ */


### PR DESCRIPTION
# Chess Engine API
The contract of the chess engine service (alias ChessPort) has been updated according to the new design. In addition:
- a getState functionality has been added to retrieve the state of the game on demand
- each functionality now returns a Future, making all functionalities asynchronous, as it should be in a distributed system The implementation of such contract has been updated and moved to io.github.chess.model.ChessGame.

The ChessBoard now acts as a simple container for the chess pieces, exposing functionalities for updating its internal data structure.
In addition:
- a ChessBoardBuilder has been added to preconfigure the creation of a chess board
- a ChessBoardBuilder.DSL has been designed to speed up the creation of a chess board and making it easier to understand (see io.github.chess.model.{ChessBoardBuilderDSLSpec, ChessBoardBuilderSpec, ChessBoardSpec} as examples on how to use it) A standard configuration of a chess board has been provided with placeholder pieces.

Minor refactoring has been applied to some of the dependencies of the service.

# Chess Application
The chess game interface has been renamed to ChessApplication. Now, the chess application does not depend directly on the chess board, but is uses a LocalChessProxy for interacting with the chess engine service. Such proxy is provided together with the main stage of the application in the ChessApplicationContext, which is unique for the entire application and it is provided as a given to any ChessApplicationComponent.

Other components of the application has been updated according to the new chess engine api. 

# Other
An OptionExtension has been added in the utilities. This extension provides the following functionalities:
- a given conversion that maps any object to an option containing that object
- a getOrThrow method, which returns the content of an option or throws an exception

A Require object has been added in the utilities. This object provides many methods for throwing exceptions in a more declarative way.

# Fix
ScalaFormatter now runs before each build, run or test.

The compiler options of the scala compiler has been changes:
- added -feature: this shows feature warnings when a scala feature that requires to be activated explicitly has been used without doing so
- added -language:implicitConversions: this allows to use given conversions without throwing feature warnings